### PR TITLE
Allow application to handle SIGHUP

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The exit triggers are handled as detailed:
    * `SIGHUP` kill signal (code `1`).
    * Any uncaught exception (code `255`).
    * Any closed connection listeners, eg. on worker disconnect (code `255`).
+* Non-exit conditions:
+  * if there is a `SIGHUP` listener registered by your application, `exiting` allows you to handle it and doesn't do anything.
+  * NOTE: ensure your `SIGHUP` handler function's name is not `abort` or `graceful`, as these are reserved names for internal `exiting` functions.
 
 If the server shutdown is too slow, a timeout will eventually trigger an exit (exit code `255`).
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -192,7 +192,7 @@ exports.Manager = function (server, options) {
     this.exitTimeout = options.exitTimeout || 5000;
 
     if (process.listenerCount('SIGHUP') > 0) {
-        internals.signals.SIGHUP = true;
+        delete internals.signals.SIGHUP;
     }
 
     this.server = server;

--- a/lib/index.js
+++ b/lib/index.js
@@ -140,16 +140,35 @@ internals.badExitCheck = function () {
     }
 };
 
+internals.hasExternalSIGHUPListener = function () {
+
+    const listeners = process.listeners('SIGHUP');
+    let externalExists = false;
+
+    listeners.forEach((listener) => {
+
+        if (listener.name !== 'abort' && listener.name !== 'graceful') {
+            externalExists = true;
+        }
+    });
+
+    return externalExists;
+};
+
 
 internals.setupExitHooks = function () {
 
     process.on('uncaughtException', internals.uncaughtExceptionHandler);
 
-    const signals = Object.keys(internals.signals);
-    for (let i = 0; i < signals.length; ++i) {
-        const handler = internals.signals[signals[i]] ? internals.gracefulHandler : internals.abortHandler;
-        process.on(signals[i], handler);
-    }
+    Object.keys(internals.signals).forEach((signal) => {
+
+        const handler = internals.signals[signal] ? internals.gracefulHandler : internals.abortHandler;
+        if (signal === 'SIGHUP' && internals.hasExternalSIGHUPListener()) {
+            return;
+        }
+
+        process.on(signal, handler);
+    });
 
     process.on('beforeExit', internals.exit);
     process.on('exit', internals.badExitCheck);
@@ -165,11 +184,11 @@ internals.teardownExitHooks = function () {
 
     process.exit = internals.processExit;
 
-    const signals = Object.keys(internals.signals);
-    for (let i = 0; i < signals.length; ++i) {
-        const handler = internals.signals[signals[i]] ? internals.gracefulHandler : internals.abortHandler;
-        process.removeListener(signals[i], handler);
-    }
+    Object.keys(internals.signals).forEach((signal) => {
+
+        const handler = internals.signals[signal] ? internals.gracefulHandler : internals.abortHandler;
+        process.removeListener(signal, handler);
+    });
 
     process.removeListener('beforeExit', internals.exit);
     process.removeListener('exit', internals.badExitCheck);
@@ -190,10 +209,6 @@ exports.Manager = function (server, options) {
     options = options || {};
 
     this.exitTimeout = options.exitTimeout || 5000;
-
-    if (process.listenerCount('SIGHUP') > 0) {
-        delete internals.signals.SIGHUP;
-    }
 
     this.server = server;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,6 +191,10 @@ exports.Manager = function (server, options) {
 
     this.exitTimeout = options.exitTimeout || 5000;
 
+    if (process.listenerCount('SIGHUP') > 0) {
+        internals.signals.SIGHUP = true;
+    }
+
     this.server = server;
 
     this.state = null;       // ['starting', 'started', 'stopping', 'prestopped', 'stopped', 'startAborted', 'errored', 'timeout']

--- a/test/exiting.js
+++ b/test/exiting.js
@@ -571,7 +571,6 @@ describe('Manager', () => {
 
             process.on('SIGHUP', () => {
 
-                console.log(manager.state);
                 expect(manager.state).to.equal('started');
                 process.exit(0);
             });

--- a/test/exiting.js
+++ b/test/exiting.js
@@ -557,4 +557,35 @@ describe('Manager', () => {
             });
         });
     });
+
+    describe('allows SIGHUP', () => {
+
+        it('to be handled if a listener exists', (done) => {
+
+            process.exit = (code) => {
+
+                // we're just cleaning up here as the
+                // process.exit is not part of this test
+                done();
+            };
+
+            process.on('SIGHUP', () => {
+
+                console.log('SIGHUP received');
+                console.log(manager.state);
+                expect(manager.state).to.equal('started');
+                process.exit(0);
+            });
+
+            const server = new Hapi.Server();
+            server.connection();
+
+            const manager = new Exiting.Manager(server).start((err) => {
+
+                expect(err).to.not.exist();
+
+                process.emit('SIGHUP');
+            });
+        });
+    });
 });

--- a/test/exiting.js
+++ b/test/exiting.js
@@ -571,7 +571,6 @@ describe('Manager', () => {
 
             process.on('SIGHUP', () => {
 
-                console.log('SIGHUP received');
                 console.log(manager.state);
                 expect(manager.state).to.equal('started');
                 process.exit(0);


### PR DESCRIPTION
* `exiting` doesn't interfere with any registered `SIGHUP` handlers/listeners
* application is free to handle `SIGHUP` as it wishes
* no config needed - check is done on the presence of an 'external' `SIGHUP` listener
* all other functionality remains the same
* two tests added, coverage still at 100%